### PR TITLE
Fix chickens in portals crashing the game

### DIFF
--- a/src/main/java/thefloydman/moremystcraft/block/BlockUnstablePortal.java
+++ b/src/main/java/thefloydman/moremystcraft/block/BlockUnstablePortal.java
@@ -232,6 +232,12 @@ public class BlockUnstablePortal extends BlockBreakable {
 		if (worldIn.isRemote) {
 			return;
 		}
+
+		// Allow non-player entities to walk through the portal without linking.
+		if (!(entityIn instanceof EntityPlayer)) {
+			return;
+		}
+
 		final TileEntity tileEntity = MoreMystcraftPortalUtils.getTileEntity((IBlockAccess) worldIn, pos);
 		if (tileEntity == null || !(tileEntity instanceof TileEntityUnstableBookReceptacle)) {
 			worldIn.setBlockToAir(pos);


### PR DESCRIPTION
This way only players will link through an unstable portal.
Alternatively non-player entities could simply vanish, but I think it's more important to preserve the player's items and mobs than to be consistent with normal portals here.

Apologies for the newline change at the end of the file, I made this change in Github's online editor and it looks like it automatically adds a trailing newline.